### PR TITLE
Fixed typo in README.md Custom failure handlers example host -> hosts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Add a custom error handler that's run when host or referer validation fails. Thi
 ```javascript
 // 
 app.use('/brew-tea', hostValidation({ 
-	host: ['office-teapot'],
+	hosts: ['office-teapot'],
 	fail: (req, res, next) => {
         // send a 418 "I'm a Teapot" Error
 		res.status(418).send('I\'m the office teapot. Refer to me only as such.')


### PR DESCRIPTION
Hi Brannon,
There is a one letter off typo in README custom error failure handlers example host -> hosts.