### PR TITLE
Improve performance in isAllowed

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function(config) {
 
 	function isAllowed(headerValue, allowedValues) {
 		if (!headerValue || !allowedValues) return false
-		const matches = allowedValues.filter(candidate => {
+		return allowedValues.some(candidate => {
 			if (typeof candidate === 'string') {
 				return candidate === headerValue
 			} else if (candidate instanceof RegExp){
@@ -96,7 +96,6 @@ module.exports = function(config) {
 			}
 			return false
 		})
-		return matches.length > 0
 	}
 
 	function checkAllowedType(type) {


### PR DESCRIPTION
`isAllowed` would previously iterate over *every* allowed value even if it had already found one that was allowed. By switching from `Array.prototype.filter` to `Array.prototype.some`, we can "short-circuit" this.

This is a minor change, but something small I spotted.

`npm test` passes after this change.